### PR TITLE
Fix dns_forced_in_dhclientconf for both Debian and Redhat system

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,4 +7,4 @@ dns_searchs:
 dns_dhclient_rule: "supersede" # can be supersede or prepend
 
 dns_dhclient_file: "/etc/dhcp/dhclient.conf"
-dns_forced_in_dhclientconf: "{{ansible_distribution == 'Ubuntu'}}"
+dns_forced_in_dhclientconf: "{{ansible_os_family == 'Debian' or ansible_os_family == 'Redhat'}}"


### PR DESCRIPTION
Made changes to modify dhclient.conf in Debian-based and Redhat-based distributions.

Tested on Debian 6, CentOS 7 and Fedora 20.

Please, review. :)
